### PR TITLE
Bumping AWS-ECR-Login Action to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push to Amazon ECR
         env:


### PR DESCRIPTION
Bumping aws-ecr-login action to v2, eliminating redundant password warning with v1 (as we aren't logging in via password)