### PR TITLE
Defining 'main' as the reference branch in our main.yml 'checkout' action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           repository: "washabstract/artemis"
           token: ${{ steps.app-token.outputs.token }}
+          ref: main
 
       - name: Update .env file
         run: sed -i '/^CYCLADES_IMAGE_TAG=/d' aws/.env && echo "CYCLADES_IMAGE_TAG=${GITHUB_SHA}" >> aws/.env


### PR DESCRIPTION
This is a one line update making 'main' the default branch to checkout under the 'checkout' action within our 'sync dags' job.  Please see the following documentation for more information: https://github.com/actions/checkout?tab=readme-ov-file#Checkout-HEAD 