### PR TITLE
Updating main.yml file to include step for OS Core dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
+      
+      - name: Ensure OpenStates-Core Dependency References Abstract Core Fork
+        run: |
+          sed -i 's|^openstates =.*|openstates = {git = "https://github.com/washabstract/cyclades-openstates-core.git"}|' pyproject.toml
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
@@ -56,7 +60,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
       
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "washabstract/artemis"
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull includes an update to include a step within our main.yml file.  This new step ensures that when pushing our new image to ECR, our pyproject.toml file references **our** OS-Core repo in lieu of the main fork.  Additionally, we are updating the 'checkout' action under the 'sync dags' job from v3 to v4.  