### PR TITLE
Reverting Dependency Update and Keeping Update for 'Checkout' Action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       
-      - name: Ensure OpenStates-Core Dependency References Abstract Core Fork
-        run: |
-          sed -i 's|^openstates =.*|openstates = {git = "https://github.com/washabstract/cyclades-openstates-core.git"}|' pyproject.toml
-
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 


### PR DESCRIPTION
This PR (1) removes our CI action that updates our OpenStates dependency within the pyproject.toml file, but (2) maintains the update for our 'Checkout' action from v3 to v4.