### PR TITLE
Changing Repo Name from Artemis to OS_Scrapes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          repository: "washabstract/artemis"
+          repository: "washabstract/os_scrapes"
           token: ${{ steps.app-token.outputs.token }}
           ref: main
 


### PR DESCRIPTION
This PR changes the repo referenced within our main.yml file from Artemis to OS_Scrapes, which is consistent with how the Athens repo references our DAG repo.