### PR TITLE
Changing Docker Tag from Commit Hash to GitHub SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,9 @@ jobs:
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
         run: |
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          docker build --platform linux/amd64 -t $DOCKER_IMAGE:$COMMIT_HASH -f Dockerfile .
-          docker tag $DOCKER_IMAGE:$COMMIT_HASH $DOCKER_IMAGE:latest
-          docker push $DOCKER_IMAGE:$COMMIT_HASH
+          docker build --platform linux/amd64 -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile .
+          docker tag $DOCKER_IMAGE:$GITHUB_SHA $DOCKER_IMAGE:latest
+          docker push $DOCKER_IMAGE:$GITHUB_SHA
           docker push $DOCKER_IMAGE:latest
 
   sync_dags:


### PR DESCRIPTION
**Description:**
This PR updates the main.yml file to tag Docker images using the full GitHub SHA. The images will now be uniquely tagged with the full SHA.  This is in line with how we are tracing images with Athens for consistency.

**Changes:**
Updated the CI script to use `${{ GITHUB_SHA }}` for Docker image tags.
Maintained the `latest` tag for the most recent image.