### PR TITLE
Cronos integration (Conjuctive PR with cyclades-core)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      
+
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push to Amazon ECR
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
+          CRONOS_ENDPOINT: $ {{ secrets.CRONOS_ENDPOINT }}
         run: |
-          docker build --platform linux/amd64 -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile .
+          docker build --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile .
           docker tag $DOCKER_IMAGE:$GITHUB_SHA $DOCKER_IMAGE:latest
           docker push $DOCKER_IMAGE:$GITHUB_SHA
           docker push $DOCKER_IMAGE:latest
@@ -40,13 +41,13 @@ jobs:
     needs: build
     name: Sync DAG with New Image Tag
     runs-on: ubuntu-latest
-  
+
     steps:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      
+
       - name: Get GitHub App Token
         uses: actions/create-github-app-token@v1
         id: app-token
@@ -54,7 +55,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: "washabstract"
-      
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -64,7 +65,7 @@ jobs:
 
       - name: Update .env file
         run: sed -i '/^CYCLADES_IMAGE_TAG=/d' artemis/aws/.env && echo "CYCLADES_IMAGE_TAG=${GITHUB_SHA}" >> artemis/aws/.env
-      
+
       - name: Configure git
         run: |
           git config --global user.name "send-pr.yml workflow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN poetry install --no-root
 
 ADD . /opt/openstates/openstates/
 
+ARG CRONOS_ENDPOINT
+ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
+
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \

--- a/scrapers/il/__init__.py
+++ b/scrapers/il/__init__.py
@@ -10,7 +10,7 @@ class Illinois(State):
         "bills": IlBillScraper,
         "events": IlEventScraper,
     }
-    legislative_sessions = [
+    hisotrical_legislative_sessions = [
         {
             "name": "90th Regular Session",
             "identifier": "90th",

--- a/scrapers/ma/__init__.py
+++ b/scrapers/ma/__init__.py
@@ -13,7 +13,7 @@ class Massachusetts(State):
         "events": MAEventScraper,
         "votes": MAVoteScraper,
     }
-    legislative_sessions = [
+    hisotrical_legislative_sessions = [
         {
             "_scraped_name": "186th",
             "classification": "primary",

--- a/scrapers/mi/__init__.py
+++ b/scrapers/mi/__init__.py
@@ -9,7 +9,7 @@ class Michigan(State):
         "bills": MIBillScraper,
         "events": MIEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011-2012",
             "classification": "primary",

--- a/scrapers/ny/__init__.py
+++ b/scrapers/ny/__init__.py
@@ -12,7 +12,7 @@ class NewYork(State):
         "bills": NYBillScraper,
         "events": NYEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009",
             "identifier": "2009-2010",

--- a/scrapers/ri/__init__.py
+++ b/scrapers/ri/__init__.py
@@ -9,7 +9,7 @@ class RhodeIsland(State):
         "bills": RIBillScraper,
         "events": RIEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2012",
             "classification": "primary",


### PR DESCRIPTION
This is a conjuctive PR [with cyclades core PR #12](https://github.com/washabstract/cyclades-openstates-core/pull/12) that introduces Cronos usage to the dags we've created so far.

Note:
- Currently, every state has an override of `legislative_sessions`, which will become a property by core PR #12. As we make scrapes, changing this to `historical_legislative_sessions` stops the override. During the scrape, whenever calling `self.legislative_sessions`, the core will use the `historical_legislative_sessions` and the cronos endpoint to create the active sessions list.