### PR TITLE
PA: Skipping Vote Event if Link is Invalid

### DIFF
--- a/scrapers/pa/bills.py
+++ b/scrapers/pa/bills.py
@@ -100,7 +100,14 @@ class PABillScraper(Scraper):
         )
 
         # only fetch votes if votes were seen in history
-        yield from self.parse_votes(bill, page)
+        # vote links are often taken down on PA website; this moves on if a vote link is missing or incorrect
+        # this will not affect the bill JSONs themselves, only the ancillary vote_event JSONs
+        try:
+            yield from self.parse_votes(bill, page)
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to parse votes for bill {bill_id}: {e}. Continuing without votes."
+            )
 
         # Dedupe sources.
         sources = bill.sources


### PR DESCRIPTION
**Issue:**
When a vote event link is invalid on the PA website, neither the vote_event JSON nor the bill JSON are pulled.

**Solution:**
To pull all bill JSONs regardless of the validity of the vote_event, we will need to skip over _just_ the vote_event in lieu of both the vote_event and the bill JSONs.

**Fix Overview:** 
This PR edits the `bills.py` file of the PA scraper module to improve the scraping of ALL bill JSONs.  As the code currently sits, if a vote event is unable to be scraped for a bill, the vote_event JSON _as well as_ the bill JSON are not scraped and skipped.  As vote event links are often missing or moved, this edit skips pulling the vote_event JSON if the link is invalid, and continues with just pulling the bill JSON in lieu of skipping over both.

