### PR TITLE
Fix github action to properly access CRONOS_ENDPOINT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build and push to Amazon ECR
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
-          CRONOS_ENDPOINT: $ {{ secrets.CRONOS_ENDPOINT }}
+          CRONOS_ENDPOINT: ${{ secrets.CRONOS_ENDPOINT }}
         run: |
           docker build -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT          
           docker tag $DOCKER_IMAGE:$GITHUB_SHA $DOCKER_IMAGE:latest


### PR DESCRIPTION
Our build process had [this issue](https://github.com/washabstract/cyclades-openstates-scrapers/actions/runs/12185645349) when building -- ty @DGieseke for catching this!!

Fix allows the proper argument for CRONOS_ENDPOINT to be passed