### PR TITLE
Adding Georgia to Cronos

### DIFF
--- a/scrapers/ga/__init__.py
+++ b/scrapers/ga/__init__.py
@@ -9,7 +9,7 @@ class Georgia(State):
         "bills": GABillScraper,
         "events": GAEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011-2012 Regular Session",
             "identifier": "2011_12",


### PR DESCRIPTION
This change to the Georgia scraper allows Georgia to begin integrating any sessions found in Cronos with those found in the openstates scrapers repo.

Note that a failed hit to the endpoint will default `legislative_sessions` to the `historical_legislative_sessions` field. In addition, any session in cronos with a shared identifier will be opted for over existing (and any new sessions that come from the upstream) sessions from `historical_legislative_sessions`