### PR TITLE
Migrate NJ to use Cronos

### DIFF
--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -12,7 +12,7 @@ class NewJersey(State):
         "bills": NJBillScraper,
         "events": NJEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2008-2009 Session",
             "identifier": "213",


### PR DESCRIPTION
Following the same procedure as other states, this fix removes the override of `legislative_sessions`, allowing the base State class' property from the core repo to be invoked by the scrape to query cronos for up to date legislative sessions