### PR TITLE
Migrate Texas to use cronos

### DIFF
--- a/scrapers/tx/__init__.py
+++ b/scrapers/tx/__init__.py
@@ -12,7 +12,7 @@ class Texas(State):
         "votes": TXVoteScraper,
         "events": TXEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "81(R) - 2009",
             "classification": "primary",


### PR DESCRIPTION
Following the same procedure as other states, this fix removes the override of legislative_sessions, allowing the base State class' property from the core repo to be invoked by the scrape to query cronos for up to date legislative sessions
