### PR TITLE
nc and fl moved to cronos

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -16,7 +16,7 @@ class Florida(State):
     }
     # Full session list through 2019:
     # https://flsenate.gov/PublishedContent/OFFICES/SECRETARY/SessionsoftheFloridaSenateFromStatehood.pdf
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "name": "2011 Regular Session",
             "identifier": "2011",

--- a/scrapers/nc/__init__.py
+++ b/scrapers/nc/__init__.py
@@ -9,7 +9,7 @@ class NorthCarolina(State):
         "bills": NCBillScraper,
         "events": NCEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "1985-1986 Session",
             "classification": "primary",


### PR DESCRIPTION
Following the same procedure as other states, this fix removes the override of legislative_sessions, allowing the base State class' property from the core repo to be invoked by the scrape to query cronos for up to date legislative sessions
