### PR TITLE
Update Indiana Scraper to Retrieve API from Secrets Manager

### DIFF
--- a/scrapers/in/__init__.py
+++ b/scrapers/in/__init__.py
@@ -13,7 +13,7 @@ class Indiana(State):
         "bills": INBillScraper,
         "events": INEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "First Regular Session 116th General Assembly (2009)",
             "identifier": "2009",

--- a/scrapers/in/__init__.py
+++ b/scrapers/in/__init__.py
@@ -3,6 +3,7 @@ import requests
 from openstates.scrape import State
 from .bills import INBillScraper
 from .events import INEventScraper
+from utils.secrets import get_secret
 
 settings = dict(SCRAPELIB_TIMEOUT=600)
 
@@ -172,7 +173,7 @@ class Indiana(State):
     ]
 
     def get_session_list(self):
-        apikey = os.environ["INDIANA_API_KEY"]
+        apikey = get_secret("INDIANA_API_KEY")
         useragent = os.getenv("USER_AGENT", "openstates")
         headers = {
             "x-api-key": apikey,

--- a/scrapers/in/apiclient.py
+++ b/scrapers/in/apiclient.py
@@ -5,6 +5,8 @@ from urllib.parse import urljoin
 import functools
 import requests
 
+from utils.secrets import get_secret
+
 """
 API key must be passed as a header. You need the following headers to get JSON:
 x-api-key = your_apikey
@@ -79,7 +81,7 @@ class ApiClient(object):
 
     def __init__(self, scraper):
         self.scraper = scraper
-        self.apikey = os.environ["INDIANA_API_KEY"]
+        self.apikey = get_secret("INDIANA_API_KEY")
         self.user_agent = os.getenv("USER_AGENT", "openstates")
 
     def get_session_no(self, session):


### PR DESCRIPTION
This PR updates the Indiana scraper module to improve how we retrieve the IN API credentials.  Additionally, we change the `legislative_sessions` list name.  Key changes include:

**API Credential Handling:**
- Updated the `__init__.py` and `apiclient.py` files to retrieve the Indiana Bill API key from AWS Secrets Manager instead of relying on environment variables.
- This change ensures a more secure and centralized approach to managing sensitive credentials.

**Session List Update:**
- Modified the session list in the scraper to be named `historical_legislative_sessions` instead of `legislative_sessions`.
- This update allows for better compatibility with our Cronos integration.