### PR TITLE
missouri and utah to cronos

### DIFF
--- a/scrapers/mo/__init__.py
+++ b/scrapers/mo/__init__.py
@@ -11,7 +11,7 @@ class Missouri(State):
         # 'votes': MOVoteScraper,
         "events": MOEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2019 Regular Session",
             "classification": "primary",

--- a/scrapers/ut/__init__.py
+++ b/scrapers/ut/__init__.py
@@ -10,7 +10,7 @@ class Utah(State):
         "events": UTEventScraper,
         "bills": UTBillScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011 General Session",
             "classification": "primary",


### PR DESCRIPTION
Here, we're making changes to Missouri and Utah in anticipation for deploying their DAGs. These changes allow us to pull new session information from Cronos. Note that no data is yet loaded for either state.