### PR TITLE
Update DC Scraper to Retrieve API from Secrets Manager

### DIFF
--- a/scrapers/dc/__init__.py
+++ b/scrapers/dc/__init__.py
@@ -3,6 +3,7 @@ import requests
 from openstates.scrape import State
 from .bills import DCBillScraper
 from .events import DCEventScraper
+from utils.secrets import get_secret
 
 
 class DistrictOfColumbia(State):
@@ -78,7 +79,7 @@ class DistrictOfColumbia(State):
     ]
 
     def get_session_list(self):
-        apikey = os.environ["DC_API_KEY"]
+        apikey = get_secret("DC_API_KEY")
         useragent = os.getenv("USER_AGENT", "openstates")
         headers = {
             "Authorization": apikey,

--- a/scrapers/dc/__init__.py
+++ b/scrapers/dc/__init__.py
@@ -11,7 +11,7 @@ class DistrictOfColumbia(State):
         "events": DCEventScraper,
         "bills": DCBillScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "19",
             "identifier": "19",

--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -8,6 +8,7 @@ from openstates.scrape import Scraper, Bill, VoteEvent
 from .actions import Bill_Categorizer, Vote_Categorizer
 
 from utils.media import get_media_type
+from utils.secrets import get_secret
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -20,7 +21,7 @@ class DCBillScraper(Scraper):
     _API_BASE_URL = "https://lims.dccouncil.gov/api/v2/PublicData/"
 
     _headers = {
-        "Authorization": os.environ["DC_API_KEY"],
+        "Authorization": get_secret("DC_API_KEY"),
         "Accept": "application/json",
         "User-Agent": os.getenv("USER_AGENT", "openstates"),
     }


### PR DESCRIPTION
This PR updates the DC scraper module to improve how we retrieve the DC API credentials. Additionally, we change the legislative_sessions list name. Key changes include:

**API Credential Handling:**
- Updated the `__init__.py` and `bills.py` files to retrieve the DC Bill API key from AWS Secrets Manager instead of relying on environment variables.

**Session List Update:**
- Modified the session list in the scraper to be named `historical_legislative_sessions` instead of `legislative_sessions`.
- This update allows for better compatibility with our Cronos integration.