### PR TITLE
Mississippi, Montana, and Nebraska to Cronos

### DIFF
--- a/scrapers/ms/__init__.py
+++ b/scrapers/ms/__init__.py
@@ -9,7 +9,7 @@ class Mississippi(State):
         "bills": MSBillScraper,
         "events": MSEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2008 Regular Session",
             "identifier": "2008",

--- a/scrapers/mt/__init__.py
+++ b/scrapers/mt/__init__.py
@@ -9,7 +9,7 @@ class Montana(State):
         "bills": MTBillScraper,
         "events": MTEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "20111",
             "identifier": "2011",

--- a/scrapers/ne/__init__.py
+++ b/scrapers/ne/__init__.py
@@ -9,7 +9,7 @@ class Nebraska(State):
         "bills": NEBillScraper,
         "events": NEEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "102nd Legislature 1st and 2nd Sessions",
             "end_date": "2012-04-18",


### PR DESCRIPTION
Here, we are introducing mississsippi, missouri, and nebraska to cronos.

Before now, we were experiencing issues with Missouri due to a failure on scraping the lower chambers. A recent merge from the upstream resolves this.

All 3 scrapers are operational in local OS testing and on airflow.