### PR TITLE
moved tennesee to cronos

### DIFF
--- a/scrapers/tn/__init__.py
+++ b/scrapers/tn/__init__.py
@@ -9,7 +9,7 @@ class Tennessee(State):
         "bills": TNBillScraper,
         "events": TNEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         # {
         #     "_scraped_name": "106th General Assembly",
         #     "classification": "primary",


### PR DESCRIPTION
This pr introduces the simple 1 line fix of moving the Tennessee scraper to use cronos to scrape.

This passed a local test scrape.