### PR TITLE
North Dakota on Cronos

### DIFF
--- a/scrapers/nd/__init__.py
+++ b/scrapers/nd/__init__.py
@@ -15,7 +15,7 @@ class NorthDakota(State):
         "bills": NDBillScraper,
         "events": NDEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "62nd Legislative Assembly (2011-12)",
             "identifier": "62",


### PR DESCRIPTION
Here, we make a change to allow the ND scraper to read from Cronos.

Note that currently the request to cronos fails. We first need to add the state and enter new session information.