### PR TITLE
South Dakota added to Cronos

### DIFF
--- a/scrapers/sd/__init__.py
+++ b/scrapers/sd/__init__.py
@@ -11,7 +11,7 @@ class SouthDakota(State):
         "bills": SDBillScraper,
         "events": SDEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009",
             "identifier": "2009",


### PR DESCRIPTION
In this P.R, we're moving the SD scraper to use cronos to retrieve new session information.