### PR TITLE
Add if/else check to VA scraper to avoid errors when LegislationTitle is missing

### DIFF
--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -74,12 +74,12 @@ class VaBillScraper(Scraper):
             # or "LegislationSummary" keys resulting in unsuccessful scrapes.  The if/else blocks below
             # get around this.
             if not isinstance(row["LegislationTitle"], str):
-                subtitle = " "
+                subtitle = ""
             else:
                 subtitle = self.text_from_html(row["LegislationTitle"])
 
             if not isinstance(row["LegislationSummary"], str):
-                description = " "
+                description = ""
             else:
                 description = self.text_from_html(row["LegislationSummary"])
 

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -69,9 +69,21 @@ class VaBillScraper(Scraper):
         for row in page["Legislations"]:
             # the short title on the VA site is 'description',
             # LegislationTitle is on top of all the versions
+
+            # Note, in several rows from 'page["Legislations"]', bills are missing the "LegislationTitle"
+            # or "LegislationSummary" keys resulting in unsuccessful scrapes.  The if/else blocks below
+            # get around this.
+            if not isinstance(row["LegislationTitle"], str):
+                subtitle = " "
+            else:
+                subtitle = self.text_from_html(row["LegislationTitle"])
+
+            if not isinstance(row["LegislationSummary"], str):
+                description = " "
+            else:
+                description = self.text_from_html(row["LegislationSummary"])
+
             title = row["Description"]
-            subtitle = self.text_from_html(row["LegislationTitle"])
-            description = self.text_from_html(row["LegislationSummary"])
 
             bill = Bill(
                 row["LegislationNumber"],


### PR DESCRIPTION
We’ve been running into a TypeError whenever a bill in Virginia doesn’t have a `LegislationTitle` or `LegislationSummary`, causing the scraper to fail. This PR fixes that by adding simple `if/else` blocks, assigning `" "` to sections where information is by default missing, and keeping relevant information if it exists.  This solution has been tested and ensures the VA scraper does not fail if it comes across these missing keys.