### PR TITLE
Adding Fix for CI PR Issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,11 @@ jobs:
 
       - name: Echo PR
         run: |
-          gh pr create --body "Changes from PR https://github.com/washabstract/cyclades-openstates-scrapers/pull/${PR}" --title "Update CYCLADES_IMAGE_TAG to ${GITHUB_SHA}"
+          gh pr create \
+          --base main \
+          --head update-image-tag-${GITHUB_SHA} \
+          --body "Changes from PR https://github.com/washabstract/cyclades-openstates-scrapers/pull/${PR}" \
+          --title "Update CYCLADES_IMAGE_TAG to ${GITHUB_SHA}"
         if: success() && steps.findPr.outputs.number
         env:
           PR: ${{ steps.findPr.outputs.pr }}


### PR DESCRIPTION
The `cyclades-openstates-scrapers` repository's CI workflow is failing when it comes to creating a PR to Artemis to update the `CYCLADES_IMAGE_TAG` . The CI workflow is successful up to the point of creating a branch within Artemis, however, [it fails at the "Echo PR" task](https://github.com/washabstract/cyclades-openstates-scrapers/actions/runs/12672172214/job/35315755811).  These revisions may avoid this.