### PR TITLE
Fix California Docker Build Failure by Using --no-root in Poetry Install

### DIFF
--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -52,7 +52,7 @@ RUN poetry install --no-root
 ADD . /opt/openstates/openstates/
 
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
-RUN poetry install --extras "california" \
+RUN poetry install --extras "california" --no-root \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \
     && apt-get remove -y -qq \
       build-essential \


### PR DESCRIPTION
This PR updates our `Dockerfile.california` to include the `--no-root` flag when installing dependencies via Poetry. Previously, the build failed with an error indicating “No file/folder found for package `openstates-scrapers`.”