### PR TITLE
Migrate all outstanding states to historical legislative sessions

### DIFF
--- a/scrapers/ak/__init__.py
+++ b/scrapers/ak/__init__.py
@@ -9,7 +9,7 @@ settings = dict(SCRAPELIB_TIMEOUT=600)
 
 class Alaska(State):
     scrapers = {"bills": AKBillScraper, "events": AKEventScraper}
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "28th Legislature (2013-2014)",
             "identifier": "28",

--- a/scrapers/al/__init__.py
+++ b/scrapers/al/__init__.py
@@ -8,7 +8,7 @@ class Alabama(State):
         "bills": ALBillScraper,
         "events": ALEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2023 First Special Session",
             "classification": "special",

--- a/scrapers/ar/__init__.py
+++ b/scrapers/ar/__init__.py
@@ -9,7 +9,7 @@ class Arkansas(State):
         "bills": ARBillScraper,
         "events": AREventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "Regular Session, 2011",
             "classification": "primary",

--- a/scrapers/az/__init__.py
+++ b/scrapers/az/__init__.py
@@ -11,7 +11,7 @@ class Arizona(State):
         "events": AZEventScraper,
         "bills": AZBillScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009 - Forty-ninth Legislature - First Regular Session",
             "classification": "primary",

--- a/scrapers/ca/__init__.py
+++ b/scrapers/ca/__init__.py
@@ -15,7 +15,7 @@ class California(State):
         "events": CAEventScraper,
         "events_web": CAEventWebScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "classification": "primary",
             "identifier": "19891990",

--- a/scrapers/co/__init__.py
+++ b/scrapers/co/__init__.py
@@ -9,7 +9,7 @@ class Colorado(State):
         "bills": COBillScraper,
         "events": COEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011 Regular Session",
             "classification": "primary",

--- a/scrapers/ct/__init__.py
+++ b/scrapers/ct/__init__.py
@@ -14,7 +14,7 @@ class Connecticut(State):
         "events": CTEventScraper,
         "votes": CTVoteScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011",
             "identifier": "2011",

--- a/scrapers/de/__init__.py
+++ b/scrapers/de/__init__.py
@@ -10,7 +10,7 @@ class Delaware(State):
         "bills": DEBillScraper,
         "events": DEEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "1998 - 2000 (GA 140)",
             "identifier": "140",

--- a/scrapers/gu/__init__.py
+++ b/scrapers/gu/__init__.py
@@ -9,7 +9,7 @@ class Guam(State):
         "events": GUEventScraper,
     }
     # sessions before 37th are missing many labels
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "37th",
             "identifier": "37th",

--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -12,7 +12,7 @@ class Hawaii(State):
         "bills": HIBillScraper,
         "events": HIEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2012",
             "identifier": "2011 Regular Session",

--- a/scrapers/id/__init__.py
+++ b/scrapers/id/__init__.py
@@ -9,7 +9,7 @@ class Idaho(State):
         "bills": IDBillScraper,
         "events": IDEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011 Session",
             "classification": "primary",

--- a/scrapers/ky/__init__.py
+++ b/scrapers/ky/__init__.py
@@ -10,7 +10,7 @@ class Kentucky(State):
         "bills": KYBillScraper,
         "events": KYEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011 Regular Session",
             "classification": "primary",

--- a/scrapers/la/__init__.py
+++ b/scrapers/la/__init__.py
@@ -9,7 +9,7 @@ class Louisiana(State):
         "events": LAEventScraper,
         "bills": LABillScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009 Regular Session",
             "classification": "primary",

--- a/scrapers/me/__init__.py
+++ b/scrapers/me/__init__.py
@@ -9,7 +9,7 @@ class Maine(State):
         "bills": MEBillScraper,
         "events": MEEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "121st Legislature",
             "identifier": "121",

--- a/scrapers/mn/__init__.py
+++ b/scrapers/mn/__init__.py
@@ -23,7 +23,7 @@ class Minnesota(State):
         "votes": MNVoteScraper,
         "events": MNEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "86th Legislature, 2009-2010",
             "classification": "primary",

--- a/scrapers/mp/__init__.py
+++ b/scrapers/mp/__init__.py
@@ -12,7 +12,7 @@ class NorthernMarianaIslands(State):
         "events": MPEventScraper,
     }
     # sessions before 37th are missing many labels
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "23",
             "identifier": "23",

--- a/scrapers/nh/__init__.py
+++ b/scrapers/nh/__init__.py
@@ -9,7 +9,7 @@ class NewHampshire(State):
         "bills": NHBillScraper,
         "events": NHEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "identifier": "2011",
             "name": "2011 Regular Session",

--- a/scrapers/nm/__init__.py
+++ b/scrapers/nm/__init__.py
@@ -11,7 +11,7 @@ class NewMexico(State):
         "events": NMEventScraper,
         "votes": NMVoteScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011 Regular",
             "identifier": "2011",

--- a/scrapers/nv/__init__.py
+++ b/scrapers/nv/__init__.py
@@ -9,7 +9,7 @@ class Nevada(State):
         "bills": NVBillScraper,
         "events": NVEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "26th (2010) Special Session",
             "classification": "special",

--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -16,7 +16,7 @@ class Oklahoma(State):
     #   - update the `_scraped_name`
     #   - update the session slug in the Bill scraper
     #   - ignore the odd-year session
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2012 Regular Session",
             "identifier": "2011-2012",

--- a/scrapers/or/__init__.py
+++ b/scrapers/or/__init__.py
@@ -10,7 +10,7 @@ class Oregon(State):
         "votes": ORVoteScraper,
         "events": OREventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2007 Regular Session",
             "identifier": "2007 Regular Session",

--- a/scrapers/pa/__init__.py
+++ b/scrapers/pa/__init__.py
@@ -12,7 +12,7 @@ class Pennsylvania(State):
         "bills": PABillScraper,
         "events": PAEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009-2010 Regular Session",
             "classification": "primary",

--- a/scrapers/pr/__init__.py
+++ b/scrapers/pr/__init__.py
@@ -14,7 +14,7 @@ class PuertoRico(State):
         "bills": PRBillScraper,
         "votes": PRVoteScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009-2012",
             "identifier": "2009-2012",

--- a/scrapers/sc/__init__.py
+++ b/scrapers/sc/__init__.py
@@ -12,7 +12,7 @@ class SouthCarolina(State):
         "bills": SCBillScraper,
         "events": SCEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "119 - (2011-2012)",
             "classification": "primary",

--- a/scrapers/usa/__init__.py
+++ b/scrapers/usa/__init__.py
@@ -15,7 +15,7 @@ class UnitedStates(State):
         "bills": USBillScraper,
         # "votes": USVoteScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "classification": "primary",
             "identifier": "115",

--- a/scrapers/va/__init__.py
+++ b/scrapers/va/__init__.py
@@ -17,7 +17,7 @@ class Virginia(State):
         "csv_bills": VaCSVBillScraper,
         "bills": VaBillScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2010 Session",
             "identifier": "2010",

--- a/scrapers/vi/__init__.py
+++ b/scrapers/vi/__init__.py
@@ -10,7 +10,7 @@ class VirginIslands(State):
         "bills": VIBillScraper,
         "events": VIEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "30",
             "classification": "primary",

--- a/scrapers/vt/__init__.py
+++ b/scrapers/vt/__init__.py
@@ -19,7 +19,7 @@ class Vermont(State):
         "bills": VTBillScraper,
         "events": VTEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009-2010 Session",
             "classification": "primary",

--- a/scrapers/wi/__init__.py
+++ b/scrapers/wi/__init__.py
@@ -9,7 +9,7 @@ class Wisconsin(State):
         "bills": WIBillScraper,
         "events": WIEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2009 Regular Session",
             "classification": "primary",

--- a/scrapers/wv/__init__.py
+++ b/scrapers/wv/__init__.py
@@ -8,7 +8,7 @@ class WestVirginia(State):
         "bills": WVBillScraper,
         "events": WVEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011",
             "classification": "primary",

--- a/scrapers/wy/__init__.py
+++ b/scrapers/wy/__init__.py
@@ -8,7 +8,7 @@ class Wyoming(State):
         "bills": WYBillScraper,
         "events": WYEventScraper,
     }
-    legislative_sessions = [
+    historical_legislative_sessions = [
         {
             "_scraped_name": "2011",
             "classification": "primary",


### PR DESCRIPTION
Some states are still not using historical_legislative_sessions. Let's fix this

- Ported remaining states to use historical_legislative_sessions, invoking the property legislative_sessions from core (and negating the overwrite)