### PR TITLE
Modifying California CI Workflow to Include Cronos Endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Build and push cyclades-scrapers-ca image to Amazon ECR
         env:
           DOCKER_IMAGE_CA: ${{ secrets.DOCKER_IMAGE_CA }}
+          CRONOS_ENDPOINT: ${{ secrets.CRONOS_ENDPOINT }}
         run: |
-          docker build -t $DOCKER_IMAGE_CA:$GITHUB_SHA -f Dockerfile.california . --platform linux/amd64        
+          docker build -t $DOCKER_IMAGE_CA:$GITHUB_SHA -f Dockerfile.california . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT
           docker tag $DOCKER_IMAGE_CA:$GITHUB_SHA $DOCKER_IMAGE_CA:latest
           docker push $DOCKER_IMAGE_CA:$GITHUB_SHA
           docker push $DOCKER_IMAGE_CA:latest

--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -57,6 +57,9 @@ RUN poetry install --no-root
 
 ADD . /opt/openstates/openstates/
 
+ARG CRONOS_ENDPOINT
+ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
+
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install --no-root  --extras "california" \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \


### PR DESCRIPTION
This PR edits our `Dockerfile.california` and `main.yml` files such that `CRONOS_ENDPOINT` is included as a variable and build argument for the California Cyclades Image in ECR.  