### PR TITLE
added cache_bucket as build args

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,9 @@ jobs:
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
           CRONOS_ENDPOINT: ${{ secrets.CRONOS_ENDPOINT }}
+          CACHE_BUCKET: ${{ secrets.CACHE_BUCKET }}
         run: |
-          docker build -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT          
+          docker build -t $DOCKER_IMAGE:$GITHUB_SHA -f Dockerfile . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT --build-arg CACHE_BUCKET=$CACHE_BUCKET       
           docker tag $DOCKER_IMAGE:$GITHUB_SHA $DOCKER_IMAGE:latest
           docker push $DOCKER_IMAGE:$GITHUB_SHA
           docker push $DOCKER_IMAGE:latest
@@ -40,8 +41,9 @@ jobs:
         env:
           DOCKER_IMAGE_CA: ${{ secrets.DOCKER_IMAGE_CA }}
           CRONOS_ENDPOINT: ${{ secrets.CRONOS_ENDPOINT }}
+          CACHE_BUCKET: ${{ secrets.CACHE_BUCKET }}
         run: |
-          docker build -t $DOCKER_IMAGE_CA:$GITHUB_SHA -f Dockerfile.california . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT
+          docker build -t $DOCKER_IMAGE_CA:$GITHUB_SHA -f Dockerfile.california . --platform linux/amd64 --build-arg CRONOS_ENDPOINT=$CRONOS_ENDPOINT --build-arg CACHE_BUCKET=$CACHE_BUCKET
           docker tag $DOCKER_IMAGE_CA:$GITHUB_SHA $DOCKER_IMAGE_CA:latest
           docker push $DOCKER_IMAGE_CA:$GITHUB_SHA
           docker push $DOCKER_IMAGE_CA:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ ADD . /opt/openstates/openstates/
 
 ARG CRONOS_ENDPOINT
 ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
+ARG CACHE_BUCKET
+ENV CACHE_BUCKET=${CACHE_BUCKET}
 ENV ARCHIVE_CACHE_TO_S3=true
 
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build

--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -59,8 +59,8 @@ ADD . /opt/openstates/openstates/
 
 ARG CRONOS_ENDPOINT
 ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
+ARG CACHE_BUCKET
 ENV CACHE_BUCKET=${CACHE_BUCKET}
-ENV ARCHIVE_CACHE_TO_S3=true
 ENV ARCHIVE_CACHE_TO_S3=true
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install --no-root  --extras "california" \

--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -59,6 +59,8 @@ ADD . /opt/openstates/openstates/
 
 ARG CRONOS_ENDPOINT
 ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
+ENV CACHE_BUCKET=${CACHE_BUCKET}
+ENV ARCHIVE_CACHE_TO_S3=true
 ENV ARCHIVE_CACHE_TO_S3=true
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install --no-root  --extras "california" \


### PR DESCRIPTION
Loading up the CACHE_BUCKET build arg

**Why did this work locally?**

Because locally, were testing with env vars and building while mounting a local .env. As a result, we had a scenario where local scrapes in python using the debugger as well as local scrapes in a local airflow instance were using the env var, though we neglected the github action and prod docker files 