### PR TITLE
Adding AWS CLI to the docker image to faciliate syncing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ ARG CACHE_BUCKET
 ENV CACHE_BUCKET=${CACHE_BUCKET}
 ENV ARCHIVE_CACHE_TO_S3=true
 
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+  && unzip -q awscliv2.zip \
+  && ./aws/install \
+  && rm -rf aws awscliv2.zip
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install --no-root \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \


### PR DESCRIPTION
We want to cache, and stratify by jurisdiction to minimize the load on start up and wind down. We also don't want weird race conditions when mulitple dags are firing off at once. What do we do?

- First, we implement cacheing stratifying by the jurisdiction as a directory within the bucket
- Secondly, we use the aws cli which better supports syncing, instead of our prior implemenation with boto3

These were both implemented in the last PR. However, in this P.R, we're updating our build so that the image itself successfully installs the AWS CLI, since we want to use subprocesses.

### Proper testing this time:
``

This time, I built and ran the image *exactly* as is done by our github action, and ran the image locally both in my terminal and a local airflow instance (not using kubernetes)

From within the image, with AWS credentials mounted, we had a successful scrape:
`20:31:10 DEBUG openstates.stats: Stat emission is not enabled.
20:31:10 INFO root: Module: mi
mi (scrape)
  bills: {}
s3://cyclades-cache/Michigan
20:31:11 INFO openstates: Syncing cache from REDACTED-CACHE-THAT-SHOWED-UP-PROPERLY
20:31:12 INFO openstates: Cache sync completed
20:31:12 INFO openstates: save jurisdiction Michigan as jurisdiction_ocd-jurisdiction-country:us-state:mi-government.json
20:31:13 INFO openstates: save organization Michigan Legislature as organization_6bb8c2b6-1001-11f0-9c41-0242ac110003.json
20:31:13 INFO openstates: save organization Senate as organization_6bb9361a-1001-11f0-9c41-0242ac110003.json
20:31:13 INFO openstates: save organization House as organization_6bb978aa-1001-11f0-9c41-0242ac110003.json
20:31:13 WARNING openstates: no session provided, using active sessions: {'2025-2026'}
s3://cyclades-cache/Michigan
20:31:13 INFO openstates: Syncing cache from S3 bucket s3://cyclades-cache
20:31:14 INFO openstates: Cache sync completed
20:31:14 INFO scrapelib: GET - 'https://legislature.mi.gov/Search/ExecuteSearch?chamber=&docTypesList=HB%2CSB&docTypesList=HR%2CSR&docTypesList=HCR%2CSCR&docTypesList=HJR%2CSJR&sessions=2025-2026&sponsor=&number=&dateFrom=&dateTo=&contentFullText='
20:31:16 INFO scrapelib: GET - 'https://legislature.mi.gov/Bills/Bill?ObjectName=2025-SB-0001'
20:31:17 INFO openstates: Found Substitute Substitute (S-1), https://legislature.mi.gov/Home/GetObject?objectName=2025-SCVBS-0001-0J217.pdf
20:31:17 INFO openstates: save bill SB 0001 in 2025-2026 as bill_6ddd1f88-1001-11f0-9c41-0242ac110003.json`
![image](https://github.com/user-attachments/assets/05bbb895-e70b-4bd9-8bd4-9f2f20f8ed0d)

We also get to validate that the session sync worked appropriately with cronos
![image](https://github.com/user-attachments/assets/dbccf7e9-5e94-4af8-871c-6d8eddec7111)

note that for the state of michigan, this was tested with a completely empty local cache and remote cache. There were no sessions at all loaded into cronos when running the  scrape for Michigan, and the sync was successful

