### PR TITLE
install AWS CLI on CA image

### DIFF
--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -62,6 +62,10 @@ ENV CRONOS_ENDPOINT=${CRONOS_ENDPOINT}
 ARG CACHE_BUCKET
 ENV CACHE_BUCKET=${CACHE_BUCKET}
 ENV ARCHIVE_CACHE_TO_S3=true
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+  && unzip -q awscliv2.zip \
+  && ./aws/install \
+  && rm -rf aws awscliv2.zip
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
 RUN poetry install --no-root  --extras "california" \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \


### PR DESCRIPTION
In this P.R, we're installing the AWS CLI in the CA dockerfile to enable cache syncing with the california bucket in the cyclades s3 caching bucket.

