### PR TITLE
poetry lock check on pr

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,14 @@ jobs:
       - name: check poetry.lock consistency
         run: |
           cp poetry.lock poetry.lock.orig
-          poetry lock --no-update
+          poetry lock
           if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
             echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
+            cat << EOF > mismatch.log
+            The poetry.lock file in the repository does not match what would be generated
+            by running 'poetry lock'. Please run 'poetry lock' locally and commit the changes.
+            EOF
+            cat mismatch.log
             exit 1
           fi
       - name: install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: install poetry
-        run: pip install poetry wheel
+        run: pip install poetry==1.8.4 wheel
       - name: check poetry.lock consistency
         run: |
           cp poetry.lock poetry.lock.orig

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
           poetry lock
           if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
             echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
+            echo "Differences:"
+            diff poetry.lock poetry.lock.orig
             exit 1
           fi
       - name: install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,4 @@
 name: Lint Python
-
 on:
   push:
     branches:
@@ -7,22 +6,28 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: setup Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
-    - name: install poetry
-      run: pip install poetry wheel
-    - name: install dependencies
-      run: poetry install --only=dev --no-root
-    - name: flake8 check
-      run: poetry run flake8 scrapers scrapers_next
-    - name: black check
-      run: poetry run black --check --diff scrapers scrapers_next
+      - uses: actions/checkout@v3
+      - name: setup Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: install poetry
+        run: pip install poetry wheel
+      - name: check poetry.lock consistency
+        run: |
+          cp poetry.lock poetry.lock.orig
+          poetry lock --no-update
+          if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
+            echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
+            exit 1
+          fi
+      - name: install dependencies
+        run: poetry install --only=dev --no-root
+      - name: flake8 check
+        run: poetry run flake8 scrapers scrapers_next
+      - name: black check
+        run: poetry run black --check --diff scrapers scrapers_next

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,6 @@ jobs:
           poetry lock
           if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
             echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
-            cat << EOF > mismatch.log
-            The poetry.lock file in the repository does not match what would be generated
-            by running 'poetry lock'. Please run 'poetry lock' locally and commit the changes.
-            EOF
-            cat mismatch.log
             exit 1
           fi
       - name: install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,13 @@ on:
       - main
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: setup Python 3.9
+      - name: setup Python 3.9.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.9.13"
       - name: install poetry
         run: pip install poetry==1.8.4 wheel
       - name: check poetry.lock consistency
@@ -24,7 +24,7 @@ jobs:
           if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
             echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
             echo "Differences:"
-            diff poetry.lock poetry.lock.orig
+            diff -u poetry.lock poetry.lock.orig
             exit 1
           fi
       - name: install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,23 +8,29 @@ on:
       - main
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: setup Python 3.9.13
+      - name: setup Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.13"
+          python-version: "3.9"
       - name: install poetry
         run: pip install poetry==1.8.4 wheel
       - name: check poetry.lock consistency
         run: |
-          cp poetry.lock poetry.lock.orig
+          # Check dependency versions without platform-specific hashes
+          poetry export -f requirements.txt --without-hashes > requirements.orig.txt
+          # Create new lock file
           poetry lock
-          if ! diff -q poetry.lock poetry.lock.orig > /dev/null; then
-            echo "Error: poetry.lock is out of sync. Please run 'poetry lock' and commit the changes."
-            echo "Differences:"
-            diff -u poetry.lock poetry.lock.orig
+          # Export requirements from the new lock file
+          poetry export -f requirements.txt --without-hashes > requirements.new.txt
+          # Compare the actual dependencies rather than the raw lock files
+          if ! diff -q requirements.orig.txt requirements.new.txt > /dev/null; then
+            echo "Error: Dependencies in poetry.lock are out of sync with pyproject.toml."
+            echo "Please run 'poetry lock' and commit the changes."
+            echo "Dependency differences:"
+            diff -u requirements.orig.txt requirements.new.txt || true
             exit 1
           fi
       - name: install dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,17 +209,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.38.1"
+version = "1.38.2"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "boto3-1.38.1-py3-none-any.whl", hash = "sha256:f192a4a34885a9e3e970b5ce5e6bec947be0f3fe6c4693b2a737c14407b12a5a"},
-    {file = "boto3-1.38.1.tar.gz", hash = "sha256:988e7fae7fd4d59798f84604d73a3a019c07b048f746c7c40258c0e656473887"},
+    {file = "boto3-1.38.2-py3-none-any.whl", hash = "sha256:ef3237b169cd906a44a32c03b3229833d923c9e9733355b329ded2151f91ec0b"},
+    {file = "boto3-1.38.2.tar.gz", hash = "sha256:53c8d44b231251fa9421dd13d968236d59fe2cf0421e077afedbf3821653fb3b"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.1,<1.39.0"
+botocore = ">=1.38.2,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.12.0,<0.13.0"
 
@@ -228,13 +228,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.1"
+version = "1.38.2"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "botocore-1.38.1-py3-none-any.whl", hash = "sha256:b1673975e3c42d0e2d1804f9f73e88961e95eac371c8f8c0a0d7e661ec3c90c3"},
-    {file = "botocore-1.38.1.tar.gz", hash = "sha256:c2eb42eeaa502f236ba894a65ea7f7241711150cc450b9d59fbbad41e741adc0"},
+    {file = "botocore-1.38.2-py3-none-any.whl", hash = "sha256:5d9cffedb1c759a058b43793d16647ed44ec87072f98a1bd6cd673ac0ae6b81d"},
+    {file = "botocore-1.38.2.tar.gz", hash = "sha256:b688a9bd17211a1eaae3a6c965ba9f3973e5435efaaa4fa201f499d3467830e1"},
 ]
 
 [package.dependencies]
@@ -601,7 +601,7 @@ us = "^3.1.1"
 type = "git"
 url = "https://github.com/washabstract/cyclades-openstates-core"
 reference = "HEAD"
-resolved_reference = "9ecf77b567dde90b1fbca04813ce62eafcccb73a"
+resolved_reference = "cecb19a0e2377c6cb9d8f37bc7fc7d46b79538e8"
 
 [[package]]
 name = "decorator"


### PR DESCRIPTION
In this P.R, we add a check that ensures that running poetry.lock matches the poetry.lock in the repo.

This is important to integrate instead of just running poetry.lock on build/merge (i.e having a step that adds a commit to run poetry.lock). Why? Because this lets us:
A. Make sure we're all developing using the same OS core
B. Makes sure locally we're testing using the proper packages (not just on build) to avoid any "ah yeah, this works" while we're locally devloping on outdated resources
C. teach discipline lol
