### PR TITLE
Fed scrapers kafka

### DIFF
--- a/federal_agencies/federal_scraper.py
+++ b/federal_agencies/federal_scraper.py
@@ -1,4 +1,9 @@
-from federal_utils import scrape_federal_agency, DEFAULT_FIELDS, send_doc_to_kafka
+from federal_utils import (
+    scrape_federal_agency,
+    DEFAULT_FIELDS,
+    send_doc_to_kafka,
+    init_kafka_producer,
+)
 import os
 import sys
 import json
@@ -101,8 +106,9 @@ def main():
     )
 
     if args.kafka:
+        kakfa_producer = init_kafka_producer(args.kafka)
         for doc in scraped_documents:
-            send_doc_to_kafka(doc, topic=args.kafka)
+            send_doc_to_kafka(doc, topic=args.kafka, kakfa_producer=kakfa_producer)
             print(f"Sent document {doc.get(args.document_title)} to Kafka")
         return
     

--- a/federal_agencies/federal_utils.py
+++ b/federal_agencies/federal_utils.py
@@ -118,10 +118,7 @@ def send_doc_to_kafka(doc_dict: dict, topic: str, kafka_producer: KafkaProducer 
     """
 
     if not kafka_producer:
-        kafka_producer = KafkaProducer(
-            bootstrap_servers=os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
-            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-        )
+        kafka_producer = init_kafka_producer(os.getenv("KAFKA_CLUSTER_NAME", ""))
 
     kafka_producer.send(topic, doc_dict)
     kafka_producer.flush()

--- a/federal_agencies/federal_utils.py
+++ b/federal_agencies/federal_utils.py
@@ -76,3 +76,22 @@ def get_all_documents_recurse(url, params):
     else:
         print(f"Error: {response.json()}")
         return []
+
+def send_doc_to_kafka(doc_dict: dict, topic: str):
+    """
+    Send a document dictionary to a Kafka topic.
+    
+    :param doc_dict: Dictionary containing document data.
+    :param topic: Kafka topic to send the document to.
+    """
+    from kafka import KafkaProducer
+    import json
+
+    producer = KafkaProducer(
+        bootstrap_servers='localhost:9092',
+        value_serializer=lambda v: json.dumps(v).encode('utf-8')
+    )
+
+    producer.send(topic, doc_dict)
+    producer.flush()
+    producer.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -607,6 +607,7 @@ chardet = "^3.0"
 click = "^8.0"
 dj_database_url = "^0.5.0"
 Django = "3.2.14"
+elasticsearch = "^7.0.0"
 gitpython = "^3.1.44"
 google-cloud-storage = "^2.18.0"
 influxdb-client = "^1.37.0"
@@ -626,7 +627,7 @@ us = "^3.1.1"
 type = "git"
 url = "https://github.com/washabstract/cyclades-openstates-core"
 reference = "HEAD"
-resolved_reference = "a471cb59f53800e5f1028bf032559bbcb6f9dcc2"
+resolved_reference = "96a2a413b4cfe52a65eb41954c6676bd624964e0"
 
 [[package]]
 name = "decorator"
@@ -695,6 +696,28 @@ groups = ["main"]
 files = [
     {file = "ebcdic-1.1.1-py2.py3-none-any.whl", hash = "sha256:33b4cb729bc2d0bf46cc1847b0e5946897cb8d3f53520c5b9aa5fa98d7e735f1"},
 ]
+
+[[package]]
+name = "elasticsearch"
+version = "7.17.12"
+description = "Python client for Elasticsearch"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<4,>=2.7"
+groups = ["main"]
+files = [
+    {file = "elasticsearch-7.17.12-py2.py3-none-any.whl", hash = "sha256:468fd5eef703c0d9238e29bcaf3a6fe4d6b092f917959fbf41f48f8fea3df2f8"},
+    {file = "elasticsearch-7.17.12.tar.gz", hash = "sha256:a1f5733ae8cf1dbf0a78593389f2503c87dd97429976099832bf0626cdfaac8b"},
+]
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.21.1,<2"
+
+[package.extras]
+async = ["aiohttp (>=3,<4)"]
+develop = ["black", "coverage", "jinja2", "mock", "pytest", "pytest-cov", "pyyaml", "requests (>=2.0.0,<3.0.0)", "sphinx (<1.7)", "sphinx-rtd-theme"]
+docs = ["sphinx (<1.7)", "sphinx-rtd-theme"]
+requests = ["requests (>=2.4.0,<3.0.0)"]
 
 [[package]]
 name = "et-xmlfile"


### PR DESCRIPTION
In this P.R, we're enabling kafka usage for the federal scrapers, allowing us to connect to our instance of kafka and allocate federal scrapers a suite of potential topics.

We introduce a function to send individual documents to kafka, and integrate it with our executive order scraper. The function can accept a topic to which to send messages.

Kafka can be enabled via the commandline arg `--kafka` followed by the topic to which to send scraped federal messages