### PR TITLE
Adding Missing Import

### DIFF
--- a/scrapers/ny/apiclient.py
+++ b/scrapers/ny/apiclient.py
@@ -1,4 +1,5 @@
 import string
+import os
 import time
 import functools
 from collections import defaultdict


### PR DESCRIPTION
Adding in a missing 'os' import in NY API Client file.