### PR TITLE
Adding Key/Value to Senate Statuses Dict

### DIFF
--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -79,6 +79,7 @@ class USBillScraper(Scraper):
         "Resolution Agreed to": "pass",
         "Resolution of Ratification Agreed to": "pass",
         "Veto Sustained": "fail",
+        "Motion to Recommit Rejected": "fail",
     }
 
     classifications = {


### PR DESCRIPTION
This fix avoids the following error we encountered last night.  Long story short, the USA scraper encountered a KeyError due to a missing status from the `senate_status` list.  This fix has been tested locally.

`[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base] Traceback (most recent call last):
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/bin/os-update", line 8, in <module>
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     sys.exit(main())
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 698, in main
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     report = do_update(args, other, juris)
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 459, in do_update
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     report['scrape'] = do_scrape(juris, args, scrapers, active_sessions)
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 174, in do_scrape
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     partial_report = scraper.do_scrape(**scrape_args, session=session)
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/scrape/base.py", line 526, in do_scrape
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     for iterobj in obj:
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]   File "/opt/openstates/openstates/scrapers/usa/bills.py", line 700, in scrape_senate_votes
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base]     result = self.senate_statuses[result_text]
[2025-07-18, 05:55:32 UTC] {{pod_manager.py:447}} INFO - [base] KeyError: 'Motion to Recommit Rejected'`
