### PR TITLE
Removing libgdal Dependency

### DIFF
--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -13,7 +13,6 @@ RUN apt-get update -qq \
       unzip \
       mdbtools \
       libpq5 \
-      libgdal32 \
       libmariadb-dev \
       mariadb-server \
       mariadb-client \


### PR DESCRIPTION
This PR amends our `Dockerfile.california` doc such that we omit the `libgdal32` reference.  This dependency caused the following CI/CD error w/r/t pushing our California image to ECR.  From my research, it doesn't look like we even use this specific dependency and is referenced under a separate name further down our list of dependencies under `libgdal-dev`.  The library is described as 'a translator library for raster geospatial data formats'.  Error:

`#6 [ 2/14] RUN apt-get update -qq     && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends       curl       wget       unzip       mdbtools       libpq5       libgdal32       libmariadb-dev       mariadb-server       mariadb-client       build-essential       git       libssl-dev       libffi-dev       freetds-dev       libxml2-dev       libxslt-dev       libyaml-dev       poppler-utils       libpq-dev       libgdal-dev       libgeos-dev     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list     && apt-get update -qq     && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends gh
#6 1.913 E: Unable to locate package libgdal32`